### PR TITLE
(fix): fixed the border size

### DIFF
--- a/musicBox/main.css
+++ b/musicBox/main.css
@@ -84,8 +84,9 @@ h1 {
 .song-details {
     text-align: center;
     margin-bottom: 30px;
+    margin-top: 30px;
     height:auto;
-    width:20vw;
+    width:20rem;
     border:4px solid rgb(0, 0, 2);
     transition:all 0.5s;
     border-radius: 30px;
@@ -97,12 +98,14 @@ h1 {
     font-weight: 700;
     color: rgb(0, 128, 0);
     margin-bottom: 10px;
+    margin-top: 10px;
 }
 
 .song-details h3 {
     font-size: 16px;
     font-weight: 600;
     color: rgb(52, 92, 0);
+    margin-bottom: 15px;
 }
 
 .player-controls {


### PR DESCRIPTION
### Description

The border overflow size on the music box is fixed.

### Checklist

- [x] I am making a proper pull request, not a spam.
- [x] I've checked the issue list before deciding what to submit.

## Related Issues or Pull Requests

Issue reference - Border-Name of the box in musicbox page #193

## Add relevant screenshot or video (if any)

![image](https://user-images.githubusercontent.com/60486289/121795442-895bf880-cc2e-11eb-815f-1497d59de9bc.png)
