### PR TITLE
Making navigation bar visible in about page

### DIFF
--- a/About/index.html
+++ b/About/index.html
@@ -37,8 +37,8 @@
         style="justify-content: flex-end"
       >
         <ul class="nav justify-content-center">
-          <li class="nav-item active">
-            <a class="nav-link" aria-current="page" href="../index.html">Home</a>
+          <li class="nav-item ">
+            <a class="nav-link" href="../index.html">Home</a>
           </li>
           <li class="nav-item">
             <a class="nav-link active" href="./About/index.html">About</a>
@@ -139,5 +139,10 @@
     
 </a>
 <script src="../main.js"></script>
+<script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4"
+      crossorigin="anonymous"
+    ></script>
 </body>
 </html>

--- a/Contact-Us/contact.html
+++ b/Contact-Us/contact.html
@@ -70,7 +70,7 @@
                 >
               </li>
               <li class="nav-item">
-                <a class="nav-link current" href="../About/index.html">About</a>
+                <a class="nav-link" href="../About/index.html">About</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link current" href="#">Contact Us</a>

--- a/index.html
+++ b/index.html
@@ -88,7 +88,6 @@
           justify-content: flex-end"
         >
           <ul class="nav justify-content-center">
-            <!--  me-auto mb-2 mb-lg-0 -->
             <li class="nav-item">
               <a class="nav-link active" aria-current="page" href="#">Home</a>
             </li>
@@ -96,12 +95,11 @@
               <a class="nav-link" href="./About/index.html">About</a>
             </li>
             <li class="nav-item">
-              
               <a class="nav-link" href="./Contact-Us/contact.html">Contact Us</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="login/login.html">Login</a>
-              </li>
+            <a class="nav-link" href="login/login.html">Login</a>
+            </li>
               <li class="nav-item">
                 <a class="nav-link" style="user-select: none;">THEME <input type="checkbox" id="switch" name="theme" /><label for="switch"
                   >Toggle</label


### PR DESCRIPTION
In mobile view in about page when we click on the menu bar the navigation bar was not getting displayed.
Closes #407 
Before:

https://user-images.githubusercontent.com/66825257/122954532-250f0680-d39d-11eb-98cc-07a90e4f74d4.mp4

After:

https://user-images.githubusercontent.com/66825257/122954666-440d9880-d39d-11eb-8aca-1906f713eadf.mp4


