### PR TITLE
login page correction (sign in and sign up sections were disintegrated) (#436)

### DIFF
--- a/login/login.css
+++ b/login/login.css
@@ -105,7 +105,7 @@ input {
 	transition: 0.5s;
 	border-bottom: 3.5px solid #2fd072;
   }
-  
+
 .navbar-light .navbar-toggler {
 	margin: 4px;
   }
@@ -320,20 +320,28 @@ a.social:hover{
 .field-icon{
 	position: absolute;
 	left: 81%;
-	top: 73%;
+	top: 63.1%;
 	z-index: 2;
 	cursor: pointer;
 }
 
 .field-icon1{
 	position: absolute;
-	top: 61%;
+	top: 60.5%;
 	left: 81%;
 	cursor: pointer;
 	z-index: 2;
 }
 
-} 
+.field-icon2{
+	position: absolute;
+	top: 77.5%;
+	left: 81%;
+	cursor: pointer;
+	z-index: 2;
+}
+
+}
 .social-container a:nth-child(1){
 	color: #1976d3;
 	font-size: 18px;
@@ -362,7 +370,7 @@ padding: 15px 0;
 }
 
 #btn1{
-	
+
 	background-size: 200% 100%;
 	transition: background-position 0.5s, color 0.5s;
 	background-image: linear-gradient(to right,darkslategray 50%, black 50%);

--- a/login/login.html
+++ b/login/login.html
@@ -76,9 +76,9 @@
 
       <input type="password" placeholder="Password" id="pass_signup"/>
       <span toggle="#password-field" class="fa fa-fw fa-eye field-icon toggle-password"></span>
-      <button>Sign Up</button>
-      <input type="password" placeholder="Password" />
-      <input type="password" placeholder="Confirm Password" />     
+      <input type="password" placeholder="Confirm Password" id="pass_signup_conf"/>
+      <span toggle="#password-field" class="fa fa-fw fa-eye field-icon2 toggle-password2"></span>
+
       <div class="button">
       <button id="btn">Sign Up</button>
       <button id="btn1">Reset</button>
@@ -98,11 +98,6 @@
       <input type="password" placeholder="Password" id="pass_signin"/>
       <span toggle="#password-field" class="fa fa-fw fa-eye field-icon1 toggle-password1"></span>
       <a href="../ForgetPas/Forget.html" class="forgot-password">Forgot your password?</a>
-      <button>Sign In</button>
-      <input type="password" placeholder="Password" />
-      <!-- <input type="checkbox" value="lsRememberMe" id="rememberMe">  -->
-      <!-- <label for="rememberMe" >Remember me</label> -->
-      <a href="#" class="forgot-password">Forgot your password?</a>
       <button id="btn" class="btn2">Sign In</button>
     </form>
   </div>
@@ -147,6 +142,16 @@ $(".toggle-password1").click(function() {
     $("#pass_signin").attr("type", "text");
   } else {
     $("#pass_signin").attr("type", "password");
+  }
+});
+
+$(".toggle-password2").click(function() {
+
+  $(this).toggleClass("fa-eye fa-eye-slash");
+  if ($("#pass_signup_conf").attr("type") == "password") {
+    $("#pass_signup_conf").attr("type", "text");
+  } else {
+    $("#pass_signup_conf").attr("type", "password");
   }
 });
 


### PR DESCRIPTION
### Description

#436 (issue number)

Both sign in and sign up sections were asking for password multiple times and the position of eye was not correct.
The login page looked disintegrated before.


### Checklist

- [x] I am making a proper pull request, not a spam.
- [x] I've checked the issue list before deciding what to submit.



## Add relevant screenshot or video (if any)

![image](https://user-images.githubusercontent.com/72750492/123104818-e9377800-d454-11eb-84ce-0edf12a2b169.png)

![image](https://user-images.githubusercontent.com/72750492/123105413-6c58ce00-d455-11eb-9d38-1ed4142e8384.png)

![image](https://user-images.githubusercontent.com/72750492/123104985-0b30fa80-d455-11eb-8321-2d3797941634.png)

