### PR TITLE
Fixes #533 : fixed cardflip text mirroring on hover 

### DIFF
--- a/style.css
+++ b/style.css
@@ -771,6 +771,9 @@ div .lines2 {
 
 .flip-card:hover .flip-card-inner {
   transform: rotateY(-180deg);
+  backface-visibility: hidden;
+  -moz-backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
 }
 
 /* Position the front and back side */


### PR DESCRIPTION
### Description 
Fixed #533 
changed backface visibility on hover in style.css .


## Screenshot 

![Screenshot from 2021-07-29 00-01-18](https://user-images.githubusercontent.com/73706697/127377566-7e6f4546-fabe-4914-a65a-c1c970406ba2.png)


