### PR TITLE
 fixes #536 : fixed card mirroring in about page

### DIFF
--- a/About/about.css
+++ b/About/about.css
@@ -583,7 +583,12 @@ footer h5 {
 /* Do an horizontal flip when you move the mouse over the flip box container */
 .flip-card:hover .flip-card-inner {
   transform: rotateY(-180deg);
+  backface-visibility: hidden;
+  -moz-backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
 }
+
+
 .flip-card-front {
   position: absolute;
   margin-top: 116px;


### PR DESCRIPTION
### Description
fixed #536

changed  the back face visibility to hidden on hover in the about.CSS



##  relevant screenshot 
![Screenshot from 2021-08-05 17-12-11](https://user-images.githubusercontent.com/73706697/128344438-953eb4e0-f710-4d77-bba3-dc22326da4ff.png)


